### PR TITLE
Convenience: color PS1 prompt, color and other aliases

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,25 @@
+
+if [ "`id -u`" -ne 0 ]; then
+    export PS1='\[\033[32;32m\]\u@\h\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    export PS1='\[\033[32;32m\]\h\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$ '
+fi
+
+# enable color support of ls and also add handy aliases
+if [ "$TERM" != "dumb" ]; then
+	eval "`dircolors -b`"
+	alias ls='ls -a --color=auto'
+	alias grep='grep --color=auto'
+	alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -l'
+alias lh='ls -lh'
+alias la='ls -Al'
+
+alias cp='cp --reflink=auto'
+
+alias b1='bitcoin-cli -datadir=1 '
+alias b2='bitcoin-cli -datadir=2 '
+alias b3='bitcoin-cli -datadir=3 '

--- a/.bashrc
+++ b/.bashrc
@@ -20,4 +20,3 @@ alias la='ls -Al'
 
 alias b1='bitcoin-cli -datadir=1 '
 alias b2='bitcoin-cli -datadir=2 '
-alias b3='bitcoin-cli -datadir=3 '

--- a/.bashrc
+++ b/.bashrc
@@ -18,8 +18,6 @@ alias ll='ls -l'
 alias lh='ls -lh'
 alias la='ls -Al'
 
-alias cp='cp --reflink=auto'
-
 alias b1='bitcoin-cli -datadir=1 '
 alias b2='bitcoin-cli -datadir=2 '
 alias b3='bitcoin-cli -datadir=3 '

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ ADD . /home/tester/bitcoin-testnet-box
 # make tester user own the bitcoin-testnet-box
 RUN chown -R tester:tester /home/tester/bitcoin-testnet-box
 
+# color PS1
+RUN mv /home/tester/bitcoin-testnet-box/.bashrc /home/tester/ && \
+	cat /home/tester/.bashrc >> /etc/bash.bashrc
+
 # use the tester user when running the image
 USER tester
 


### PR DESCRIPTION
Color PS1 prompt makes it easier to differentiate between bitcoin-cli and shell commands

Other shell aliases also for convenience