### PR TITLE
Bitcoin Core .17 requires new configuration for regtest 

### DIFF
--- a/1/bitcoin.conf
+++ b/1/bitcoin.conf
@@ -5,7 +5,7 @@ upnp=0
 
 # listen on different ports than default testnet
 port=19000
-rpcport=19001
+regtest.rpcport=19001
 
 # always run a server, even with bitcoin-qt
 server=1
@@ -13,7 +13,7 @@ server=1
 # enable SSL for RPC server
 #rpcssl=1
 
-rpcallowip=0.0.0.0/0
+regtest.rpcallowip=0.0.0.0/0
 
-rpcuser=admin1
-rpcpassword=123
+regtest.rpcuser=admin1
+regtest.rpcpassword=123

--- a/2/bitcoin.conf
+++ b/2/bitcoin.conf
@@ -9,7 +9,7 @@ connect=127.0.0.1:19000
 
 # listen on different ports than default testnet
 port=19010
-rpcport=19011
+regtest.rpcport=19011
 
 # always run a server, even with bitcoin-qt
 server=1
@@ -17,7 +17,7 @@ server=1
 # enable SSL for RPC server
 #rpcssl=1
 
-rpcallowip=0.0.0.0/0
+regtest.rpcallowip=0.0.0.0/0
 
-rpcuser=admin2
-rpcpassword=123
+regtest.rpcuser=admin2
+regtest.rpcpassword=123


### PR DESCRIPTION
As per https://bitcoin.stackexchange.com/questions/80739/connection-refused/80740#80740

we need to update and specify eg. `regtest.rpcport`.. in order to be compatible with 0.17, otherwise it gives connection refused.